### PR TITLE
Fix favorite color usage in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ features: {
         "greeting": "Hello!"
     },
     "<OWNER>/<REPO>/color": {
-        "color": "green" 
+        "favorite": "green" 
     }
 }
 ```


### PR DESCRIPTION
The README shows to use `"color"` as a property, but `install.sh` checks for `_BUILD_ARG_COLOR_FAVORITE` (https://github.com/microsoft/dev-container-features-template/blob/main/install.sh#L40)

This PR makes the usage match the processing. Manually tested. After rebuilding, I get green text as expected